### PR TITLE
Add open access data inputs and web scraper tests

### DIFF
--- a/data/open_access_papers.csv
+++ b/data/open_access_papers.csv
@@ -1,0 +1,3 @@
+Title,PDF_URL
+"Dissimilar laser welding of an as-rolled CoCrFeMnNi high entropy alloy to Inconel 718 superalloy","https://www.sciencedirect.com/science/article/pii/S0030399224008855/pdfft?pid=1-s2.0-S0030399224008855-main.pdf"
+"Multiscale characterization of NiTi shape memory alloy to Ti6Al4V dissimilar laser welded joints","https://www.sciencedirect.com/science/article/pii/S0030399224013112/pdfft?pid=1-s2.0-S0030399224013112-main.pdf"

--- a/data/sources.csv
+++ b/data/sources.csv
@@ -1,0 +1,2 @@
+Website
+https://photon-science.desy.de/facilities/petra_iii/beamlines/p07_high_energy_materials_science/publications_from_p07/2025/index_eng.html

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import web_scraper
+
+DATA_DIR = ROOT_DIR / "data"
+
+
+def test_load_open_access_papers_returns_expected_entries():
+    papers = web_scraper.load_open_access_papers(DATA_DIR / "open_access_papers.csv")
+
+    assert len(papers) == 2
+    assert papers[0].title == (
+        "Dissimilar laser welding of an as-rolled CoCrFeMnNi high entropy alloy to Inconel 718 superalloy"
+    )
+    assert papers[0].pdf_url.startswith("https://www.sciencedirect.com/")
+    assert papers[1].title.startswith("Multiscale characterization of NiTi shape memory alloy")
+
+
+def test_load_sources_returns_expected_entries():
+    sources = web_scraper.load_sources(DATA_DIR / "sources.csv")
+
+    assert sources == [
+        web_scraper.Source(
+            "https://photon-science.desy.de/facilities/petra_iii/beamlines/p07_high_energy_materials_science/publications_from_p07/2025/index_eng.html"
+        )
+    ]
+
+
+def test_build_scrape_jobs_pairs_each_source_with_each_paper():
+    papers = web_scraper.load_open_access_papers(DATA_DIR / "open_access_papers.csv")
+    sources = web_scraper.load_sources(DATA_DIR / "sources.csv")
+
+    jobs = web_scraper.build_scrape_jobs(sources, papers)
+
+    assert len(jobs) == len(sources) * len(papers)
+    assert jobs[0].source == sources[0]
+    assert jobs[0].paper == papers[0]
+    assert jobs[1].paper == papers[1]
+
+
+def test_build_scrape_jobs_requires_sources_or_papers():
+    papers = web_scraper.load_open_access_papers(DATA_DIR / "open_access_papers.csv")
+    sources = web_scraper.load_sources(DATA_DIR / "sources.csv")
+
+    with pytest.raises(web_scraper.InputFileError):
+        web_scraper.build_scrape_jobs([], papers)
+
+    with pytest.raises(web_scraper.InputFileError):
+        web_scraper.build_scrape_jobs(sources, [])

--- a/web_scraper.py
+++ b/web_scraper.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class Paper:
+    """Representation of an open access paper entry."""
+
+    title: str
+    pdf_url: str
+
+
+@dataclass(frozen=True)
+class Source:
+    """Representation of a source website entry."""
+
+    url: str
+
+
+@dataclass(frozen=True)
+class ScrapeJob:
+    """Pairing of a source with a paper to be scraped."""
+
+    source: Source
+    paper: Paper
+
+
+class InputFileError(ValueError):
+    """Raised when an input CSV file is missing required information."""
+
+
+REQUIRED_PAPER_HEADERS = {"Title", "PDF_URL"}
+REQUIRED_SOURCE_HEADERS = {"Website"}
+
+
+def _normalise_path(path: Path | str) -> Path:
+    resolved = Path(path)
+    if not resolved.exists():
+        raise FileNotFoundError(f"Input file not found: {resolved}")
+    return resolved
+
+
+def load_open_access_papers(path: Path | str) -> List[Paper]:
+    """Load paper entries from ``open_access_papers.csv``."""
+
+    file_path = _normalise_path(path)
+    with file_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        headers = set(reader.fieldnames or [])
+        missing_headers = REQUIRED_PAPER_HEADERS - headers
+        if missing_headers:
+            raise InputFileError(
+                f"Missing required paper columns {sorted(missing_headers)} in {file_path}"
+            )
+
+        papers: List[Paper] = []
+        for index, row in enumerate(reader, start=2):
+            title = (row.get("Title") or "").strip()
+            pdf_url = (row.get("PDF_URL") or "").strip()
+            if not title or not pdf_url:
+                raise InputFileError(
+                    f"Row {index} in {file_path} is missing title or PDF URL."
+                )
+            papers.append(Paper(title=title, pdf_url=pdf_url))
+
+    if not papers:
+        raise InputFileError(f"No paper entries were found in {file_path}.")
+
+    return papers
+
+
+def load_sources(path: Path | str) -> List[Source]:
+    """Load source entries from ``sources.csv``."""
+
+    file_path = _normalise_path(path)
+    with file_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        headers = set(reader.fieldnames or [])
+        missing_headers = REQUIRED_SOURCE_HEADERS - headers
+        if missing_headers:
+            raise InputFileError(
+                f"Missing required source columns {sorted(missing_headers)} in {file_path}"
+            )
+
+        sources: List[Source] = []
+        for index, row in enumerate(reader, start=2):
+            url = (row.get("Website") or "").strip()
+            if not url:
+                raise InputFileError(
+                    f"Row {index} in {file_path} is missing a website URL."
+                )
+            sources.append(Source(url=url))
+
+    if not sources:
+        raise InputFileError(f"No source entries were found in {file_path}.")
+
+    return sources
+
+
+def build_scrape_jobs(
+    sources: Sequence[Source], papers: Sequence[Paper]
+) -> List[ScrapeJob]:
+    """Combine sources and papers into scrape jobs."""
+
+    if not sources:
+        raise InputFileError("At least one source is required to build scrape jobs.")
+    if not papers:
+        raise InputFileError("At least one paper is required to build scrape jobs.")
+
+    return [ScrapeJob(source=source, paper=paper) for source in sources for paper in papers]
+
+
+def iter_paper_urls(papers: Iterable[Paper]) -> Iterable[str]:
+    """Yield PDF URLs from the provided paper entries."""
+
+    for paper in papers:
+        yield paper.pdf_url


### PR DESCRIPTION
## Summary
- add CSV files containing open access papers and source URLs for the scraper
- implement helper utilities for loading the CSV inputs and assembling scrape jobs
- add pytest coverage to verify the scraper utilities work with the new data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6907dd819528832a800425b7288dd24e