### PR TITLE
Add Gemini API environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Gemini API credentials for Helmholtz OS
+# Replace the placeholder value with the actual secret in your local .env file.
+MH_GEMINI_API_KEY=""
+
+# Optional metadata about the Gemini key configuration
+MH_GEMINI_KEY_NAME="llm-project"
+MH_GEMINI_PROJECT="projects/275324365137"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Environment variable files
+.env
+.env.local
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+
+# Jupyter notebooks checkpoints
+.ipynb_checkpoints/
+
+# OS metadata
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add an environment example file that documents the Gemini API credentials and related metadata
- ignore local environment files and common Python artifacts to keep secrets out of version control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907f5239a30832aac294aeff31ae847