### PR TITLE
Gemini PDF-to-Markdown workflow

### DIFF
--- a/pdf_to_markdown.py
+++ b/pdf_to_markdown.py
@@ -1,0 +1,106 @@
+"""Convert a PDF into Markdown using Gemini 1.5 Pro and extracted images.
+
+This script splits the pages of a PDF into JPEG images and sends each page to
+Google's Gemini API requesting a Markdown reconstruction of the content. The
+Markdown for each page is saved to a single output file, with page images stored
+in a dedicated directory.
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import List
+
+from google.api_core.exceptions import DeadlineExceeded, ResourceExhausted
+import google.generativeai as genai
+from pdf2image import convert_from_path
+from PIL import Image
+from tqdm import tqdm
+
+
+PDF_PATH = "input.pdf"
+OUTPUT_MD = "output_with_images.md"
+IMAGES_DIR = "pdf_images"
+API_KEY = os.getenv("GEMINI_API_KEY") or "YOUR_GEMINI_API_KEY"
+MODEL_NAME = "gemini-1.5-pro"
+DPI = 200
+RETRY_LIMIT = 3
+IMAGE_QUALITY = 80
+
+
+def split_pdf_to_images(
+    pdf_path: str,
+    dpi: int,
+    converter=convert_from_path,
+) -> List[Image.Image]:
+    """Split a PDF into images using the provided DPI."""
+
+    return converter(pdf_path, dpi=dpi)
+
+
+def extract_markdown_from_pages(
+    pages: List[Image.Image],
+    images_dir: str = IMAGES_DIR,
+    image_quality: int = IMAGE_QUALITY,
+    retry_limit: int = RETRY_LIMIT,
+    api_key: str = API_KEY,
+    model_name: str = MODEL_NAME,
+    sleep_fn=time.sleep,
+    genai_module=genai,
+    model=None,
+) -> List[str]:
+    """Process each page image through Gemini and return Markdown snippets."""
+
+    if model is None:
+        genai_module.configure(api_key=api_key)
+        model = genai_module.GenerativeModel(model_name)
+
+    Path(images_dir).mkdir(exist_ok=True)
+
+    results: List[str] = []
+    for i, page in enumerate(tqdm(pages, desc="Processing pages")):
+        img_name = f"page_{i + 1}.jpg"
+        img_path = os.path.join(images_dir, img_name)
+
+        page.save(img_path, "JPEG", quality=image_quality)
+
+        for attempt in range(retry_limit):
+            try:
+                with open(img_path, "rb") as image_file:
+                    prompt = (
+                        "Extract this page into Markdown, keeping tables, code, and layout. "
+                        "If this page includes images, refer to them as "
+                        f"`![Page {i + 1}]({img_path})` at the appropriate place in the text."
+                    )
+                    response = model.generate_content([image_file, prompt])
+                results.append(f"## Page {i + 1}\n\n{response.text}")
+                break
+            except (ResourceExhausted, DeadlineExceeded):
+                print(f"Retry {attempt + 1} for page {i + 1} due to rate/time limits.")
+                sleep_fn(5)
+            except Exception as exc:  # pragma: no cover - defensive programming
+                print(f"Error on page {i + 1}: {exc}")
+                results.append(f"\n<!-- Page {i + 1} failed -->\n")
+                break
+    return results
+
+
+def save_markdown(snippets: List[str], output_path: str = OUTPUT_MD) -> None:
+    """Save the combined Markdown output to disk."""
+    markdown_output = "\n\n---\n\n".join(snippets)
+    with open(output_path, "w", encoding="utf-8") as output_file:
+        output_file.write(markdown_output)
+
+
+
+def main() -> None:
+    pages = split_pdf_to_images(PDF_PATH, DPI)
+    markdown_snippets = extract_markdown_from_pages(pages)
+    save_markdown(markdown_snippets)
+    print(f"\n✅ Done! Markdown saved to: {OUTPUT_MD}")
+    print(f"🖼️ Images stored in: {IMAGES_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 pytest>=7.0
+pdf2image
+Pillow
+tqdm
+google-generativeai

--- a/tests/test_pdf_to_markdown.py
+++ b/tests/test_pdf_to_markdown.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import List
+
+import pytest
+
+
+def _load_pdf_to_markdown_module():
+    module_path = Path(__file__).resolve().parents[1] / "pdf_to_markdown.py"
+
+    google_module = types.ModuleType("google")
+    api_core_module = types.ModuleType("google.api_core")
+    exceptions_module = types.ModuleType("google.api_core.exceptions")
+
+    class _TransientError(Exception):
+        pass
+
+    exceptions_module.ResourceExhausted = _TransientError
+    exceptions_module.DeadlineExceeded = _TransientError
+
+    api_core_module.exceptions = exceptions_module
+    google_module.api_core = api_core_module
+
+    generative_module = types.ModuleType("google.generativeai")
+
+    class DummyGenerativeModel:
+        def __init__(self, *_args, **_kwargs):  # pragma: no cover - stub
+            raise AssertionError("This stub should not be instantiated in tests")
+
+    def configure(**_kwargs):  # pragma: no cover - stub
+        raise AssertionError("configure should not be called in tests")
+
+    generative_module.GenerativeModel = DummyGenerativeModel
+    generative_module.configure = configure
+
+    sys.modules.setdefault("google", google_module)
+    sys.modules.setdefault("google.api_core", api_core_module)
+    sys.modules.setdefault("google.api_core.exceptions", exceptions_module)
+    sys.modules.setdefault("google.generativeai", generative_module)
+
+    pdf2image_module = types.ModuleType("pdf2image")
+
+    def _convert_from_path(*_args, **_kwargs):  # pragma: no cover - stub
+        raise AssertionError("pdf2image.convert_from_path should not be used in tests")
+
+    pdf2image_module.convert_from_path = _convert_from_path
+
+    pil_module = types.ModuleType("PIL")
+    pil_image_module = types.ModuleType("PIL.Image")
+
+    class _PlaceholderImage:  # pragma: no cover - stub
+        pass
+
+    pil_image_module.Image = _PlaceholderImage
+    pil_module.Image = pil_image_module
+
+    tqdm_module = types.ModuleType("tqdm")
+
+    def _tqdm(iterable, **_kwargs):  # pragma: no cover - stub
+        return iterable
+
+    tqdm_module.tqdm = _tqdm
+
+    sys.modules.setdefault("pdf2image", pdf2image_module)
+    sys.modules.setdefault("PIL", pil_module)
+    sys.modules.setdefault("PIL.Image", pil_image_module)
+    sys.modules.setdefault("tqdm", tqdm_module)
+
+    spec = importlib.util.spec_from_file_location("pdf_to_markdown", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pdf_to_markdown"] = module
+    assert spec.loader is not None  # for mypy
+    spec.loader.exec_module(module)
+    return module
+
+
+ptm = _load_pdf_to_markdown_module()
+
+
+class DummyResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class DummyModel:
+    def __init__(self, responses: List[str]) -> None:
+        self._responses = iter(responses)
+        self.calls = []
+
+    def generate_content(self, args):
+        self.calls.append(args)
+        return DummyResponse(next(self._responses))
+
+
+class DummyImage:
+    def __init__(self) -> None:
+        self.saved_paths = []
+
+    def save(self, path: str, _format: str, quality: int) -> None:  # pragma: no cover - trivial
+        self.saved_paths.append((path, quality))
+        Path(path).write_bytes(b"fake image data")
+
+
+@pytest.fixture()
+def sample_image() -> DummyImage:
+    return DummyImage()
+
+
+def test_extract_markdown_from_pages_saves_images_and_returns_markdown(tmp_path: Path, sample_image: DummyImage):
+    images_dir = tmp_path / "images"
+    dummy_model = DummyModel(["markdown output"])
+
+    snippets = ptm.extract_markdown_from_pages(
+        [sample_image],
+        images_dir=str(images_dir),
+        model=dummy_model,
+        genai_module=None,  # bypass configuration
+    )
+
+    assert snippets == ["## Page 1\n\nmarkdown output"]
+    expected_image = images_dir / "page_1.jpg"
+    assert expected_image.exists()
+    assert dummy_model.calls[0][1] == (
+        "Extract this page into Markdown, keeping tables, code, and layout. "
+        "If this page includes images, refer to them as "
+        f"`![Page 1]({expected_image})` at the appropriate place in the text."
+    )
+
+
+def test_extract_markdown_retries_on_transient_errors(tmp_path: Path, sample_image: DummyImage):
+    images_dir = tmp_path / "images"
+
+    class FlakyModel:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def generate_content(self, _):
+            self.calls += 1
+            if self.calls == 1:
+                raise ptm.ResourceExhausted("transient")
+            return DummyResponse("second attempt")
+
+    sleep_calls = []
+
+    def fake_sleep(seconds: int) -> None:  # pragma: no cover - trivial
+        sleep_calls.append(seconds)
+
+    model = FlakyModel()
+
+    snippets = ptm.extract_markdown_from_pages(
+        [sample_image],
+        images_dir=str(images_dir),
+        model=model,
+        genai_module=None,
+        retry_limit=3,
+        sleep_fn=fake_sleep,
+    )
+
+    assert snippets == ["## Page 1\n\nsecond attempt"]
+    assert sleep_calls == [5]
+    assert model.calls == 2
+
+
+def test_save_markdown_writes_joined_output(tmp_path: Path):
+    output_path = tmp_path / "output.md"
+
+    ptm.save_markdown(["first", "second"], output_path=str(output_path))
+
+    assert output_path.read_text(encoding="utf-8") == "first\n\n---\n\nsecond"
+
+
+def test_split_pdf_to_images_uses_provided_converter():
+    calls = {}
+
+    def fake_convert(path, dpi):
+        calls["path"] = path
+        calls["dpi"] = dpi
+        return ["image"]
+
+    result = ptm.split_pdf_to_images("some.pdf", 144, converter=fake_convert)
+
+    assert result == ["image"]
+    assert calls == {"path": "some.pdf", "dpi": 144}


### PR DESCRIPTION
## Summary
- parameterize the PDF-to-Markdown script to allow dependency injection of external services and I/O
- add comprehensive unit tests for the Gemini conversion workflow, including retry logic and output persistence stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6907fa0c8f80832ab53486ae246fc755