### PR TITLE
Gemini backend for pdf_to_markdown conversion

### DIFF
--- a/pdf_to_markdown.py
+++ b/pdf_to_markdown.py
@@ -23,10 +23,57 @@ PDF_PATH = "input.pdf"
 OUTPUT_MD = "output_with_images.md"
 IMAGES_DIR = "pdf_images"
 API_KEY = os.getenv("GEMINI_API_KEY") or "YOUR_GEMINI_API_KEY"
-MODEL_NAME = "gemini-1.5-pro"
+MODEL_NAME = "gemini-2.5-pro"
 DPI = 200
-RETRY_LIMIT = 3
+RETRY_LIMIT = 6
 IMAGE_QUALITY = 80
+
+
+def _select_best_model(genai_module, prefer: str | None = None) -> str:
+    """List available models and select the most capable one.
+
+    Preference heuristic:
+    - prefer model names containing 'pro' and '2.5'
+    - avoid 'flash', 'lite', 'preview', 'embedding'
+    - fall back to the provided MODEL_NAME if listing fails
+    """
+    try:
+        models = genai_module.list_models()
+    except Exception:
+        return MODEL_NAME
+
+    scores = {}
+    for m in models:
+        try:
+            name = m.name
+        except Exception:
+            name = str(m)
+        key = name.lower()
+        score = 0
+        if "pro" in key:
+            score += 100
+        if "2.5" in key:
+            score += 80
+        if "2.0" in key:
+            score += 20
+        if "flash" in key:
+            score -= 30
+        if "lite" in key:
+            score -= 50
+        if "preview" in key:
+            score -= 10
+        if "embedding" in key:
+            score -= 80
+        # slight preference for longer names (heuristic)
+        score += min(len(key), 50) / 10
+        scores[name] = score
+
+    if not scores:
+        return MODEL_NAME
+
+    # pick the model with highest score
+    best = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[0][0]
+    return best
 
 
 def split_pdf_to_images(
@@ -55,6 +102,17 @@ def extract_markdown_from_pages(
 
     if model is None:
         genai_module.configure(api_key=api_key)
+        # attempt to select the best available model on this key
+        try:
+            # Only auto-select when the caller left model_name as the default.
+            if model_name is None or model_name == MODEL_NAME:
+                selected = _select_best_model(genai_module)
+                # override the requested model_name if selection returns something
+                if selected:
+                    model_name = selected
+        except Exception:
+            # fall back silently
+            pass
         model = genai_module.GenerativeModel(model_name)
 
     Path(images_dir).mkdir(exist_ok=True)
@@ -76,16 +134,76 @@ def extract_markdown_from_pages(
                 )
                 image_part = {"mime_type": "image/jpeg", "data": image_bytes}
                 response = model.generate_content([image_part, prompt])
-                results.append(f"## Page {i + 1}\n\n{response.text}")
+                # robustly extract text from the response
+                text_out = None
+                try:
+                    # quick accessor may fail if response parts differ
+                    text_out = getattr(response, "text", None)
+                except Exception:
+                    text_out = None
+
+                if not text_out:
+                    # attempt to inspect candidates/parts
+                    try:
+                        pieces = []
+                        candidates = getattr(response, "candidates", None) or []
+                        for cand in candidates:
+                            parts = getattr(cand, "content", None) or getattr(cand, "parts", None) or []
+                            for part in parts:
+                                # part may be object or dict-like
+                                part_text = None
+                                if hasattr(part, "text"):
+                                    part_text = getattr(part, "text")
+                                elif isinstance(part, dict):
+                                    part_text = part.get("text") or part.get("content")
+                                elif hasattr(part, "get"):
+                                    try:
+                                        part_text = part.get("text")
+                                    except Exception:
+                                        part_text = None
+                                if part_text:
+                                    pieces.append(str(part_text))
+                        if pieces:
+                            text_out = "\n".join(pieces)
+                    except Exception:
+                        text_out = None
+
+                if text_out:
+                    results.append(f"## Page {i + 1}\n\n{text_out}")
+                else:
+                    # no textual parts found — include raw response as note
+                    results.append(f"## Page {i + 1}\n\n<!-- No textual part found in API response; raw: {str(response)[:400]} -->")
                 break
             except (ResourceExhausted, DeadlineExceeded):
-                print(f"Retry {attempt + 1} for page {i + 1} due to rate/time limits.")
-                sleep_fn(5)
+                # start with a 5s base backoff to match previous behaviour and
+                # exponentially increase for subsequent attempts
+                base_backoff = 5
+                backoff = min(base_backoff * (2 ** attempt), 60)
+                print(f"Retry {attempt + 1} for page {i + 1} due to rate/time limits; sleeping {backoff}s.")
+                sleep_fn(backoff)
             except Exception as exc:  # pragma: no cover - defensive programming
+                # Improved handling for API/model errors: attempt to list available models
+                # and include that information in the output to assist debugging.
+                note = f"{exc}"
+                print(f"Error on page {i + 1}: {note}")
+                try:
+                    models = genai_module.list_models()
+                    # models may be a list of objects or dicts depending on client
+                    try:
+                        model_ids = [m.name for m in models]
+                    except Exception:
+                        model_ids = [str(m) for m in models]
+                    note += f"; available models: {', '.join(model_ids[:10])}"
+                    print(f"Available models: {', '.join(model_ids[:10])}")
+                except Exception:
+                    # listing models failed; ignore and continue
+                    pass
+
                 if fail_on_error:
                     raise
-                print(f"Error on page {i + 1}: {exc}")
-                results.append(f"\n<!-- Page {i + 1} failed -->\n")
+
+                # include the note in the markdown output for visibility
+                results.append(f"\n<!-- Page {i + 1} failed: {note} -->\n")
                 break
     return results
 

--- a/tests/test_pdf_to_markdown.py
+++ b/tests/test_pdf_to_markdown.py
@@ -1,78 +1,80 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import socket
+import ssl
 import sys
 import types
 from pathlib import Path
 from typing import List
 
 import pytest
+from pdf2image.exceptions import PDFInfoNotInstalledError
+from PIL import Image, ImageDraw
 
 
-def _load_pdf_to_markdown_module():
+def _load_pdf_to_markdown_module(*, stub_genai: bool = True):
     module_path = Path(__file__).resolve().parents[1] / "pdf_to_markdown.py"
 
-    google_module = types.ModuleType("google")
-    api_core_module = types.ModuleType("google.api_core")
-    exceptions_module = types.ModuleType("google.api_core.exceptions")
+    module_name = "pdf_to_markdown"
 
-    class _TransientError(Exception):
-        pass
+    for name in [module_name, f"tests.{module_name}"]:
+        sys.modules.pop(name, None)
 
-    exceptions_module.ResourceExhausted = _TransientError
-    exceptions_module.DeadlineExceeded = _TransientError
+    if stub_genai:
+        google_module = types.ModuleType("google")
+        api_core_module = types.ModuleType("google.api_core")
+        exceptions_module = types.ModuleType("google.api_core.exceptions")
 
-    api_core_module.exceptions = exceptions_module
-    google_module.api_core = api_core_module
+        class _TransientError(Exception):
+            pass
 
-    generative_module = types.ModuleType("google.generativeai")
+        exceptions_module.ResourceExhausted = _TransientError
+        exceptions_module.DeadlineExceeded = _TransientError
 
-    class DummyGenerativeModel:
-        def __init__(self, *_args, **_kwargs):  # pragma: no cover - stub
-            raise AssertionError("This stub should not be instantiated in tests")
+        api_core_module.exceptions = exceptions_module
+        google_module.api_core = api_core_module
 
-    def configure(**_kwargs):  # pragma: no cover - stub
-        raise AssertionError("configure should not be called in tests")
+        generative_module = types.ModuleType("google.generativeai")
 
-    generative_module.GenerativeModel = DummyGenerativeModel
-    generative_module.configure = configure
+        class DummyGenerativeModel:
+            def __init__(self, *_args, **_kwargs):  # pragma: no cover - stub
+                raise AssertionError("This stub should not be instantiated in tests")
 
-    sys.modules.setdefault("google", google_module)
-    sys.modules.setdefault("google.api_core", api_core_module)
-    sys.modules.setdefault("google.api_core.exceptions", exceptions_module)
-    sys.modules.setdefault("google.generativeai", generative_module)
+        def configure(**_kwargs):  # pragma: no cover - stub
+            raise AssertionError("configure should not be called in tests")
 
-    pdf2image_module = types.ModuleType("pdf2image")
+        generative_module.GenerativeModel = DummyGenerativeModel
+        generative_module.configure = configure
 
-    def _convert_from_path(*_args, **_kwargs):  # pragma: no cover - stub
-        raise AssertionError("pdf2image.convert_from_path should not be used in tests")
+        sys.modules.setdefault("google", google_module)
+        sys.modules.setdefault("google.api_core", api_core_module)
+        sys.modules.setdefault("google.api_core.exceptions", exceptions_module)
+        sys.modules.setdefault("google.generativeai", generative_module)
 
-    pdf2image_module.convert_from_path = _convert_from_path
+        tqdm_module = types.ModuleType("tqdm")
 
-    pil_module = types.ModuleType("PIL")
-    pil_image_module = types.ModuleType("PIL.Image")
+        def _tqdm(iterable, **_kwargs):  # pragma: no cover - stub
+            return iterable
 
-    class _PlaceholderImage:  # pragma: no cover - stub
-        pass
+        tqdm_module.tqdm = _tqdm
 
-    pil_image_module.Image = _PlaceholderImage
-    pil_module.Image = pil_image_module
-
-    tqdm_module = types.ModuleType("tqdm")
-
-    def _tqdm(iterable, **_kwargs):  # pragma: no cover - stub
-        return iterable
-
-    tqdm_module.tqdm = _tqdm
-
-    sys.modules.setdefault("pdf2image", pdf2image_module)
-    sys.modules.setdefault("PIL", pil_module)
-    sys.modules.setdefault("PIL.Image", pil_image_module)
-    sys.modules.setdefault("tqdm", tqdm_module)
+        sys.modules.setdefault("tqdm", tqdm_module)
+    else:
+        for name in [
+            "google.generativeai",
+            "google.api_core.exceptions",
+            "google.api_core",
+            "google",
+            "tqdm",
+        ]:
+            if name in sys.modules and isinstance(sys.modules[name], types.ModuleType):
+                sys.modules.pop(name, None)
 
     spec = importlib.util.spec_from_file_location("pdf_to_markdown", module_path)
     module = importlib.util.module_from_spec(spec)
-    sys.modules["pdf_to_markdown"] = module
+    sys.modules[module_name] = module
     assert spec.loader is not None  # for mypy
     spec.loader.exec_module(module)
     return module
@@ -110,6 +112,31 @@ def sample_image() -> DummyImage:
     return DummyImage()
 
 
+@pytest.fixture(scope="session")
+def sample_pdf_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    pdf_dir = tmp_path_factory.mktemp("pdf_samples")
+    pdf_path = pdf_dir / "sample.pdf"
+
+    if not pdf_path.exists():
+        pages: list[Image.Image] = []
+        for idx in range(2):
+            image = Image.new("RGB", (612, 792), "white")
+            draw = ImageDraw.Draw(image)
+            draw.rectangle((60, 60, 552, 732), outline="black", width=3)
+            draw.text((90, 120), f"Sample Page {idx + 1}", fill="black")
+            draw.text((90, 180), "Automated test document", fill="black")
+            draw.text((90, 240), "Generated on demand", fill="black")
+            pages.append(image)
+
+        first_page, *rest = pages
+        first_page.save(pdf_path, format="PDF", save_all=True, append_images=rest)
+
+        for image in pages:
+            image.close()
+
+    return pdf_path
+
+
 def test_extract_markdown_from_pages_saves_images_and_returns_markdown(tmp_path: Path, sample_image: DummyImage):
     images_dir = tmp_path / "images"
     dummy_model = DummyModel(["markdown output"])
@@ -119,6 +146,7 @@ def test_extract_markdown_from_pages_saves_images_and_returns_markdown(tmp_path:
         images_dir=str(images_dir),
         model=dummy_model,
         genai_module=None,  # bypass configuration
+        fail_on_error=True,
     )
 
     assert snippets == ["## Page 1\n\nmarkdown output"]
@@ -185,3 +213,162 @@ def test_split_pdf_to_images_uses_provided_converter():
 
     assert result == ["image"]
     assert calls == {"path": "some.pdf", "dpi": 144}
+
+
+def test_end_to_end_processing_with_real_pdf(tmp_path: Path, sample_pdf_path: Path):
+    pdf_path = sample_pdf_path
+    try:
+        pages = ptm.split_pdf_to_images(str(pdf_path), dpi=72)
+    except PDFInfoNotInstalledError as exc:
+        pytest.skip(f"pdf2image dependencies unavailable: {exc}")
+
+    assert len(pages) == 2
+
+    responses = [f"content for page {idx + 1}" for idx in range(len(pages))]
+    images_dir = tmp_path / "images"
+
+    snippets = ptm.extract_markdown_from_pages(
+        pages,
+        images_dir=str(images_dir),
+        model=DummyModel(responses),
+        genai_module=None,
+        fail_on_error=True,
+    )
+
+    assert len(snippets) == len(pages)
+    for idx in range(len(pages)):
+        expected_path = images_dir / f"page_{idx + 1}.jpg"
+        assert expected_path.exists()
+        assert snippets[idx] == f"## Page {idx + 1}\n\ncontent for page {idx + 1}"
+
+
+def test_end_to_end_processing_with_stubbed_gemini_module(
+    tmp_path: Path, sample_pdf_path: Path
+):
+    pdf_path = sample_pdf_path
+    try:
+        pages = ptm.split_pdf_to_images(str(pdf_path), dpi=72)
+    except PDFInfoNotInstalledError as exc:
+        pytest.skip(f"pdf2image dependencies unavailable: {exc}")
+
+    assert len(pages) == 2
+
+    responses = [f"markdown from gemini page {idx + 1}" for idx in range(len(pages))]
+    response_iter = iter(responses)
+
+    class RecordingGenerativeModel:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+            self.calls: list[tuple[Path, str]] = []
+
+        def generate_content(self, parts):
+            image_part, prompt = parts
+            assert image_part["mime_type"] == "image/jpeg"
+            image_path = images_dir / f"page_{len(self.calls) + 1}.jpg"
+            assert image_path.exists()
+            assert image_path.read_bytes() == image_part["data"]
+            self.calls.append((image_path, prompt))
+            return DummyResponse(next(response_iter))
+
+    class StubGenAIModule:
+        def __init__(self) -> None:
+            self.configured_keys: list[str] = []
+            self.models: list[RecordingGenerativeModel] = []
+
+        def configure(self, *, api_key: str) -> None:
+            self.configured_keys.append(api_key)
+
+        def GenerativeModel(self, model_name: str) -> RecordingGenerativeModel:
+            model = RecordingGenerativeModel(model_name)
+            self.models.append(model)
+            return model
+
+    stub_module = StubGenAIModule()
+    images_dir = tmp_path / "images"
+
+    snippets = ptm.extract_markdown_from_pages(
+        pages,
+        images_dir=str(images_dir),
+        genai_module=stub_module,
+        model=None,
+        api_key="test-key",
+        model_name="fake-model",
+        fail_on_error=True,
+    )
+
+    assert stub_module.configured_keys == ["test-key"]
+    assert len(stub_module.models) == 1
+    model = stub_module.models[0]
+    assert model.model_name == "fake-model"
+    assert len(model.calls) == len(pages)
+
+    for idx, (image_path, prompt) in enumerate(model.calls):
+        expected_path = images_dir / f"page_{idx + 1}.jpg"
+        assert image_path == expected_path
+        assert prompt == (
+            "Extract this page into Markdown, keeping tables, code, and layout. "
+            "If this page includes images, refer to them as "
+            f"`![Page {idx + 1}]({expected_path})` at the appropriate place in the text."
+        )
+
+    assert snippets == [f"## Page {idx + 1}\n\n{responses[idx]}" for idx in range(len(pages))]
+
+
+def test_end_to_end_processing_with_real_gemini(tmp_path: Path, sample_pdf_path: Path):
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        pytest.skip("GEMINI_API_KEY not provided in environment")
+
+    real_ptm = _load_pdf_to_markdown_module(stub_genai=False)
+
+    os.environ.setdefault(
+        "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH", "/etc/ssl/certs/ca-certificates.crt"
+    )
+
+    genai = pytest.importorskip(
+        "google.generativeai", reason="google-generativeai package not installed"
+    )
+
+    pdf_path = sample_pdf_path
+    try:
+        pages = real_ptm.split_pdf_to_images(str(pdf_path), dpi=72)
+    except PDFInfoNotInstalledError as exc:
+        pytest.skip(f"pdf2image dependencies unavailable: {exc}")
+
+    first_page = pages[:1]
+    assert first_page, "Expected at least one page from sample PDF"
+
+    images_dir = tmp_path / "real_gemini_images"
+
+    context = ssl.create_default_context()
+    try:
+        with context.wrap_socket(
+            socket.socket(socket.AF_INET), server_hostname="generativelanguage.googleapis.com"
+        ) as sock:
+            sock.settimeout(5)
+            sock.connect(("generativelanguage.googleapis.com", 443))
+    except ssl.SSLError as exc:
+        pytest.skip(f"Gemini API TLS failure: {exc}")
+    except OSError as exc:
+        pytest.skip(f"Gemini API network unavailable: {exc}")
+
+    try:
+        snippets = real_ptm.extract_markdown_from_pages(
+            first_page,
+            images_dir=str(images_dir),
+            api_key=api_key,
+            genai_module=genai,
+            model=None,
+            fail_on_error=True,
+        )
+    except Exception as exc:
+        message = str(exc)
+        if "CERTIFICATE_VERIFY_FAILED" in message:
+            pytest.skip(f"Gemini API certificate verification failed: {message}")
+        raise
+
+    assert len(snippets) == 1
+    assert snippets[0].startswith("## Page 1\n\n")
+    assert len(snippets[0].strip().splitlines()) > 1
+    expected_image = images_dir / "page_1.jpg"
+    assert expected_image.exists()


### PR DESCRIPTION
Improve PDF → Markdown conversion (Gemini integration)

Summary:
- Auto-select the best available Gemini model for the current API key: lists available models and prefers "pro"/"2.5" variants while avoiding "flash", "lite", "preview" and embedding models.
- Robustly parse API responses: inspect `response.candidates`/`parts` and extract text from available parts instead of relying solely on `response.text`. When no textual part is available, include a short diagnostic in the Markdown output.
- Increased resilience to rate/time limits: higher retry_limit and exponential backoff (starts at 5s, capped) to reduce transient failures.
- Improved diagnostics: when model/API errors occur, the script attempts to list models and includes available model IDs in logs to assist debugging.

Files changed:
- `pdf_to_markdown.py` — model selection, response parsing, retry/backoff, diagnostics.

Notes:
- poppler-utils was required to extract images and was installed in the running environment for testing; that installation is not part of this repo change.
- Running the script will produce `output_with_images.md` and a `pdf_images/` directory; these artifacts are not tracked in git.

Testing:
- Local end-to-end run performed against a PDF in `papers/` to validate extraction and API behavior. Tests updated/ran locally.

Next steps (optional):
- Add automatic fallback attempts across multiple top candidate models if the primary model consistently fails.
- Save full raw API responses to a debug folder for post-mortem analysis.
