### PR TITLE
Auto-apply Gazebo startup camera to side profile for UR3 simulation

### DIFF
--- a/ur3_pick_place_docker/ws/run_ur3_three_terminals.sh
+++ b/ur3_pick_place_docker/ws/run_ur3_three_terminals.sh
@@ -28,6 +28,10 @@ CMD2='ros2 launch moveit_config move_group.launch.py'
 CMD3='python3 /ws/src/UR3_ROS2_PICK_AND_PLACE/ur_system_tests/scripts/arm_gripper_loop_controller.py'
 
 SLEEP_BETWEEN="${SLEEP_BETWEEN:-2}"
+SET_GAZEBO_CAMERA="${SET_GAZEBO_CAMERA:-1}"
+CAMERA_WAIT_TIMEOUT="${CAMERA_WAIT_TIMEOUT:-45}"
+# Side-profile default: battery/cylinder on left and UR3 on right at startup.
+GAZEBO_CAMERA_REQ="${GAZEBO_CAMERA_REQ:-pose: {position: {x: 2.45, y: -1.35, z: 1.25}, orientation: {x: -0.12, y: 0.33, z: 0.89, w: 0.28}}}"
 
 run_in_terminal() {
   local cmd="$1"
@@ -47,7 +51,46 @@ run_in_terminal() {
   esac
 }
 
+set_gazebo_camera() {
+  local -i timeout_s="$1"
+  local req="$2"
+
+  if ! command -v gz >/dev/null 2>&1; then
+    echo "[camera] gz CLI not found; skipping camera setup." >&2
+    return 0
+  fi
+
+  echo "[camera] Waiting for /gui/move_to/pose service (timeout ${timeout_s}s)..."
+  local -i waited=0
+  until gz service -l 2>/dev/null | grep -q '^/gui/move_to/pose$'; do
+    sleep 1
+    waited=$((waited + 1))
+    if (( waited >= timeout_s )); then
+      echo "[camera] Timeout waiting for /gui/move_to/pose; skipping camera setup." >&2
+      return 0
+    fi
+  done
+
+  echo "[camera] Applying startup camera pose."
+  gz service -s /gui/move_to/pose \
+    --reqtype gz.msgs.GUICamera \
+    --reptype gz.msgs.Boolean \
+    --timeout 5000 \
+    --req "$req" || echo "[camera] Failed to apply camera pose." >&2
+}
+
 run_in_terminal "${PREFIX}${CMD1}"
+
+if [[ "$SET_GAZEBO_CAMERA" == "1" ]]; then
+  (
+    if [[ -n "$ROS_SETUP" ]]; then
+      # shellcheck disable=SC1090
+      source "$ROS_SETUP"
+    fi
+    set_gazebo_camera "$CAMERA_WAIT_TIMEOUT" "$GAZEBO_CAMERA_REQ"
+  ) &
+fi
+
 sleep "$SLEEP_BETWEEN"
 run_in_terminal "${PREFIX}${CMD2}"
 sleep "$SLEEP_BETWEEN"


### PR DESCRIPTION
### Motivation
- Ensure the Gazebo GUI opens with a useful profile view of the UR3 arm so users do not need to manually zoom/pan every run. 
- The desired initial framing is a side/profile view with the red battery cylinder on the left and the robot arm on the right.

### Description
- Added environment flags `SET_GAZEBO_CAMERA`, `CAMERA_WAIT_TIMEOUT`, and `GAZEBO_CAMERA_REQ` with sensible defaults to `ur3_pick_place_docker/ws/run_ur3_three_terminals.sh` so camera behavior is configurable. 
- Implemented `set_gazebo_camera()` which waits for the `/gui/move_to/pose` service and calls `gz service -s /gui/move_to/pose` with a `gz.msgs.GUICamera` request to set the GUI camera pose. 
- Invoke the camera helper in the background right after launching Gazebo while preserving the existing launch order for MoveIt and the loop controller. 
- Default `GAZEBO_CAMERA_REQ` is tuned for a battery-left / arm-right side-profile view and can be overridden via the environment.

### Testing
- Ran a syntax check with `bash -n ur3_pick_place_docker/ws/run_ur3_three_terminals.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85b69dc94832a83140b03ab8f1c4a)